### PR TITLE
Hero.GG Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,5 +104,10 @@
             <artifactId>jackson-datatype-joda</artifactId>
             <version>2.5.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20090211</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/metacodestudio/hotsuploader/models/ReplayFile.java
+++ b/src/main/java/com/metacodestudio/hotsuploader/models/ReplayFile.java
@@ -55,12 +55,17 @@ public class ReplayFile {
 
     @JsonIgnore
     public Status getStatus() {
-        // TODO MAKE MULTIPROVIDER-FRIENDLY
-        if (uploadStatuses.size() < 1) {
+        if (uploadStatuses.size() < 2) {
             System.out.println("Empty status list");
             return Status.NEW;
         }
-        return uploadStatuses.get(0).getStatus();
+
+        Status hotsLogStatus = uploadStatuses.get(0).getStatus();
+        Status heroGGStatus = uploadStatuses.get(1).getStatus();
+        if (heroGGStatus == Status.EXCEPTION || heroGGStatus == Status.NEW)
+            return heroGGStatus;
+        else
+            return hotsLogStatus;
     }
 
     public File getFile() {

--- a/src/main/java/com/metacodestudio/hotsuploader/providers/HeroGGProvider.java
+++ b/src/main/java/com/metacodestudio/hotsuploader/providers/HeroGGProvider.java
@@ -1,0 +1,106 @@
+package com.metacodestudio.hotsuploader.providers;
+
+import com.metacodestudio.hotsuploader.models.ReplayFile;
+import com.metacodestudio.hotsuploader.models.Status;
+import org.apache.commons.codec.binary.Base64;
+import org.json.*;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.UUID;
+
+public class HeroGGProvider extends Provider {
+
+    private static final String ACCESS_KEY_ID = "beta:anQA9aBp";
+    private static final String ENCODING = "UTF-8";
+
+    public HeroGGProvider() {
+        super("Hero.GG");
+    }
+
+    @Override
+    public Status upload(final ReplayFile replayFile) {
+        String uri = "http://upload.hero.gg/ajax/upload-replay";
+
+        String boundary = String.format("----------%s", UUID.randomUUID().toString().replaceAll("-", ""));
+        String contentType = "multipart/form-data; boundary=" + boundary;
+        byte[] fileData = getFileData(replayFile, boundary);
+
+        try {
+            URL url = new URL(uri);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setDoOutput(true);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", contentType);
+            connection.setRequestProperty("User-Agent", "HeroGG");
+            connection.setFixedLengthStreamingMode((long) fileData.length);
+            connection.setRequestProperty("Authorization", "Basic " + new String(Base64.encodeBase64(ACCESS_KEY_ID.getBytes(ENCODING))));
+
+            OutputStream requestStream = connection.getOutputStream();
+            requestStream.write(fileData, 0, fileData.length);
+            requestStream.close();
+
+            InputStream responseStream = connection.getInputStream();
+            byte[] b = new byte[responseStream.available()];
+            responseStream.read(b);
+            responseStream.close();
+
+            String result = new String(b, Charset.defaultCharset());
+            JSONObject resultObj = new JSONObject(result);
+            String status = resultObj.getString("success");
+
+            if (status == "true")
+                return Status.UPLOADED;
+            else
+                return Status.EXCEPTION;
+
+        } catch (Exception e) {
+            return Status.EXCEPTION;
+        }
+
+    }
+
+    private byte[] getFileData(final ReplayFile replayFile, String boundary) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        String key = getContentString(boundary, "key", "Nothing goes here at the moment");
+        String name = getContentString(boundary, "name", replayFile.getFile().getName());
+        String file = getContentString(boundary, "file", replayFile.getFile());
+        String closing = "\r\n--" + boundary + "--\r\n";
+        String newLine = "\r\n";
+
+        try {
+            byte[] fileContents = Files.readAllBytes(replayFile.getFile().toPath());
+
+            stream.write(key.getBytes(ENCODING));
+            stream.write(newLine.getBytes(ENCODING));
+            stream.write(name.getBytes(ENCODING));
+            stream.write(newLine.getBytes(ENCODING));
+            stream.write(file.getBytes(ENCODING));
+            stream.write(fileContents);
+            stream.write(closing.getBytes(ENCODING));
+            return stream.toByteArray();
+
+        } catch (IOException e) {
+            return null;
+        }
+
+    }
+
+    private String getContentString(String boundary, String key, String value) {
+        Object[] params = new Object[]{boundary, key, value};
+        String s = String.format("--%1$s\r\nContent-Disposition: form-data; name=\"%2$s\"\r\n\r\n%3$s", params);
+
+        return s;
+    }
+
+    private String getContentString(String boundary, String key, File value) {
+        Object[] params = new Object[]{boundary, key, value.getName(), "application/x-www-form-urlencoded"};
+        String s = String.format("--%1$s\r\nContent-Disposition: form-data; name=\"%2$s\"; filename=\"%3$s\"\r\nContent-Type: %4$s\r\n\r\n", params);
+
+        return s;
+    }
+}

--- a/src/main/java/com/metacodestudio/hotsuploader/providers/Provider.java
+++ b/src/main/java/com/metacodestudio/hotsuploader/providers/Provider.java
@@ -17,9 +17,9 @@ public abstract class Provider {
     }
 
     public static List<Provider> getAll() {
-        // TODO ADD MORE PROVIDERS
         List<Provider> providers = new ArrayList<>();
         providers.add(new HotsLogsProvider());
+        providers.add(new HeroGGProvider());
         return providers;
     }
 


### PR DESCRIPTION
I added support for Hero.GG which currently just uploads to both and makes sure that it only shows as uploaded if it is uploaded on both. I didn't do any UI changes as I didn't want to step into that, but it might be nice to be able to see which providers the file is uploaded on or if it failed which one it failed on and also having the option to disable providers would probably be needed before putting this into the release.