### PR TITLE
Fixed a bug where CMD+Q or exiting the application in windows fashion…

### DIFF
--- a/src/main/java/com/metacodestudio/hotsuploader/Client.java
+++ b/src/main/java/com/metacodestudio/hotsuploader/Client.java
@@ -114,6 +114,8 @@ public class Client extends Application {
             } catch (AWTException e) {
                 e.printStackTrace();
             }
+        }else{
+            primaryStage.setOnCloseRequest(event -> System.exit(0));
         }
     }
 


### PR DESCRIPTION
… caused application freeze on OS X. Referenced in issue: https://github.com/eivindveg/HotSUploader/issues/20

Tested reinstalling after rebuilding via .dmg, and it now exits correctly.

