### PR TITLE
Set current github version string dynamically

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>2.0-SNAPSHOT</version>
     
     <prerequisites>
-       <maven>3.0</maven>
-     </prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
 
     <contributors>
         <contributor>
@@ -80,22 +80,22 @@
                     </execution>
                 </executions>
             </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <archive>
-            <index>true</index>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-              <mainClass>${mainClass}</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <index>true</index>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <mainClass>${mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
     <version>2.0-SNAPSHOT</version>
+    
+    <prerequisites>
+       <maven>3.0</maven>
+     </prerequisites>
 
     <contributors>
         <contributor>
@@ -76,11 +80,28 @@
                     </execution>
                 </executions>
             </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.6</version>
+        <configuration>
+          <archive>
+            <index>true</index>
+            <manifest>
+              <addClasspath>true</addClasspath>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              <mainClass>${mainClass}</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
             <plugin>
                 <groupId>com.zenjava</groupId>
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>8.1.5</version>
                 <configuration>
+                	<updateExistingJar>true</updateExistingJar>
                     <mainClass>${mainClass}</mainClass>
                     <nativeReleaseVersion>${releaseVersion}</nativeReleaseVersion>
                     <identifier>${project.build.finalName}</identifier>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/versions/ReleaseManager.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/versions/ReleaseManager.java
@@ -15,15 +15,13 @@
 package ninja.eivind.hotsreplayuploader.versions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import ninja.eivind.hotsreplayuploader.models.ReplayFile;
-import ninja.eivind.hotsreplayuploader.utils.FileUtils;
+
 import ninja.eivind.hotsreplayuploader.utils.SimpleHttpClient;
 import ninja.eivind.hotsreplayuploader.utils.StormHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,7 +31,9 @@ import java.util.Optional;
 public class ReleaseManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ReleaseManager.class);
-    protected static final String CURRENT_VERSION = "2.0-SNAPSHOT";
+    /**implementation version will be set by the maven build, so may be null at development**/
+    protected static final String CURRENT_VERSION
+            = ReleaseManager.class.getPackage().getImplementationVersion();
     protected static final String GITHUB_MAINTAINER = "eivindveg";
     protected static final String GITHUB_REPOSITORY = "HotSUploader";
     protected static final String GITHUB_RELEASES_ALL
@@ -77,8 +77,6 @@ public class ReleaseManager {
             LOG.error("Unable to get latest versions", e);
         }
         return Optional.empty();
-
-
     }
 
     private List<GitHubRelease> getLatest() throws IOException {
@@ -98,11 +96,11 @@ public class ReleaseManager {
     protected String getCurrentReleaseString() {
         return GITHUB_FORMAT_VERSION.replace("{maintainer}", GITHUB_MAINTAINER)
                 .replace("{repository}", GITHUB_REPOSITORY)
-                .replace("{version}", CURRENT_VERSION);
+                .replace("{version}", getCurrentVersion());
     }
 
     public String getCurrentVersion() {
-        return CURRENT_VERSION;
+        return CURRENT_VERSION != null ? CURRENT_VERSION : "Development";
     }
 
     public void setHttpClient(SimpleHttpClient httpClient) {

--- a/src/test/java/ninja/eivind/hotsreplayuploader/versions/ReleaseManagerTest.java
+++ b/src/test/java/ninja/eivind/hotsreplayuploader/versions/ReleaseManagerTest.java
@@ -58,7 +58,7 @@ public class ReleaseManagerTest {
 
     @Test
     public void testCurrentReleaseIsTheSameAsPomVersion() throws Exception {
-        String currentVersion = ReleaseManager.CURRENT_VERSION;
+        String currentVersion = releaseManager.getCurrentVersion();
 
         Document parse = Jsoup.parse(new File("pom.xml"), "UTF-8");
         String pomVersion = parse.select("project > version").text();


### PR DESCRIPTION
We probably should not set the current version string manually and read it from the manifest instead.

The only drawback would be, that this approach isn't properly testable anymore, `ReleaseManagerTest.testCurrentReleaseIsTheSameAsPomVersion()` will fail. 
That's because `getImplementationVersion()` will be set **after** the maven build and therefore won't be present at test time.

I also added a maven minimum version requirement, because the clean module needs atleast 3.0. This way `mvn versions:display-plugin-updates` will run without complaining.

I would like to discuss this, would you prefer the manual version due to testability?