### PR TITLE
add compare by identity, don't compare by status(this will solve itse…

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
@@ -28,15 +28,18 @@ import java.util.Comparator;
 public class ReplayFileComparator implements Comparator<ReplayFile> {
     @Override
     public int compare(ReplayFile o1, ReplayFile o2) {
-        if(o1.getStatus() == Status.EXCEPTION && o2.getStatus() != Status.EXCEPTION) {
-            return 1;
-        } else if(o2.getStatus() == Status.EXCEPTION && o1.getStatus() != Status.EXCEPTION) {
-            return -1;
+        if(o1 == o2) {
+            return 0;
         }
 
         File file1 = o1.getFile();
         File file2 = o2.getFile();
 
-        return -Long.compare(file1.lastModified(), file2.lastModified());
+        int modified = -Long.compare(file1.lastModified(), file2.lastModified());
+        if(modified != 0) {
+            return modified;
+        }
+
+        throw new IllegalStateException("No two different replays can be equal.");
     }
 }

--- a/src/test/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparatorTest.java
+++ b/src/test/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparatorTest.java
@@ -37,7 +37,10 @@ public class ReplayFileComparatorTest {
         comparator = new ReplayFileComparator();
     }
 
-    @Test
+    /**
+     * @deprecated in favour of no status check
+     */
+    @Deprecated
     public void testCompareByStatus() throws Exception {
         ReplayFile expection = new ReplayFile(mock(File.class));
         expection.getUploadStatuses().add(new UploadStatus("test", Status.EXCEPTION));


### PR DESCRIPTION
I seem to have fixed it by removing the status comparison. This is crucial, because we lose the "sort by status" functionality. However, newer replays that are not "exception" will be added to the top of the list, so this will only be noticeable for cases where you start fresh.