### PR TITLE
added shutdown method for closing everything properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,14 @@
                 <role>Linux maintainer</role>
             </roles>
         </developer>
+        <developer>
+            <name>Philipp Gruhn</name>
+            <email>philipp.gruhn gmail com</email>
+            <timezone>CET</timezone>
+            <roles>
+                <role>OS X maintainer</role>
+            </roles>
+        </developer>
     </developers>
 
     <contributors>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -15,7 +15,6 @@
 package ninja.eivind.hotsreplayuploader;
 
 import com.gluonhq.ignite.DIContext;
-import com.sun.javafx.application.LauncherImpl;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -71,6 +70,14 @@ public class Client extends Application {
     @Override
     public void init() {
         context.init();
+
+        //add a shutdown hook to be really sure, resources are closed properly
+        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+            @Override
+            public void run() {
+                context.dispose();
+            }
+        }));
     }
 
     @Override

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -72,11 +72,8 @@ public class Client extends Application {
         context.init();
 
         //add a shutdown hook to be really sure, resources are closed properly
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
-            @Override
-            public void run() {
-                context.dispose();
-            }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            context.dispose();
         }));
     }
 

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -72,9 +72,7 @@ public class Client extends Application {
         context.init();
 
         //add a shutdown hook to be really sure, resources are closed properly
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            context.dispose();
-        }));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> context.dispose()));
     }
 
     @Override

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -60,11 +60,9 @@ public class Client extends Application {
 
     @Override
     public void stop() throws Exception {
-        if (trayIcon != null) {
-            SystemTray.getSystemTray().remove(trayIcon);
-        }
         context.dispose();
         super.stop();
+        System.exit(0);
     }
 
     @Override

--- a/src/main/java/ninja/eivind/hotsreplayuploader/files/WatchHandler.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/files/WatchHandler.java
@@ -62,7 +62,7 @@ public class WatchHandler implements Runnable {
             try {
                 key = watchService.take();
             } catch (InterruptedException e) {
-                LOG.info(getClass().getSimpleName() + " was interrupted. Winding down thread.", e);
+                LOG.info(getClass().getSimpleName() + " was interrupted. Winding down thread.");
                 break;
             }
             for (final WatchEvent<?> watchEvent : key.pollEvents()) {

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
@@ -56,16 +56,6 @@ public class OSXService implements PlatformService {
     }
 
     @Override
-    public void shutdown()
-    {
-        //politely call the default cleanup routine
-        PlatformService.super.shutdown();
-        //event threads like AWT are still keeping the application alive, kill them
-        System.exit(0);
-    }
-
-
-    @Override
     public URL getLogoUrl() {
         String logoVariant = isMacMenuBarDarkMode() ? "" : "-black";
         return getClass().getResource(

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
@@ -56,6 +56,16 @@ public class OSXService implements PlatformService {
     }
 
     @Override
+    public void shutdown()
+    {
+        //politely call the default cleanup routine
+        PlatformService.super.shutdown();
+        //event threads like AWT are still keeping the application alive, kill them
+        System.exit(0);
+    }
+
+
+    @Override
     public URL getLogoUrl() {
         String logoVariant = isMacMenuBarDarkMode() ? "" : "-black";
         return getClass().getResource(

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
@@ -14,7 +14,6 @@
 
 package ninja.eivind.hotsreplayuploader.services.platform;
 
-import javafx.application.Platform;
 import javafx.event.EventType;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -71,7 +70,7 @@ public class OSXService implements PlatformService {
             if (event.isMetaDown()) {
                 if (event.getCode() == KeyCode.Q) {
                     LOG.info("Exiting application due to keyboard shortcut.");
-                    Platform.exit();
+                    shutdown();
                 } else if (event.getCode() == KeyCode.H) {
                     LOG.info("Hiding application due to keyboard shortcut.");
                     primaryStage.setIconified(true);

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
@@ -81,7 +81,7 @@ public interface PlatformService {
 
     /**
      * Shuts down the application by delegating service cleanups
-     * to the Application Thread, may also kill the VM depending on the OS.
+     * to the Application Thread.
      */
     default void shutdown() {
         // let JavaFX shut close its services gracefully

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
@@ -81,13 +81,11 @@ public interface PlatformService {
 
     /**
      * Shuts down the application by delegating service cleanups
-     * to the Application Thread and elminating any running non-daemon threads.
+     * to the Application Thread, may also kill the VM depending on the OS.
      */
     default void shutdown() {
-        //let JavaFX shut close its services gracefully
+        // let JavaFX shut close its services gracefully
         Platform.exit();
-        //event threads like AWT are still keeping the application alive, kill them
-        System.exit(0);
     }
 
     void browse(URI uri) throws IOException;

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
@@ -16,7 +16,6 @@ package ninja.eivind.hotsreplayuploader.services.platform;
 
 import javafx.application.Platform;
 import javafx.stage.Stage;
-import ninja.eivind.hotsreplayuploader.utils.StormHandler;
 import ninja.eivind.hotsreplayuploader.utils.Constants;
 
 
@@ -74,10 +73,21 @@ public interface PlatformService {
         });
         showItem.addActionListener(e -> openAction.run());
         exitItem.addActionListener(event -> {
-            Platform.exit();
+            shutdown();
         });
         return trayIcon;
 
+    }
+
+    /**
+     * Shuts down the application by delegating service cleanups
+     * to the Application Thread and elminating any running non-daemon threads.
+     */
+    default void shutdown() {
+        //let JavaFX shut close its services gracefully
+        Platform.exit();
+        //event threads like AWT are still keeping the application alive, kill them
+        System.exit(0);
     }
 
     void browse(URI uri) throws IOException;


### PR DESCRIPTION
As mentioned in #16, it should be safe to call System.exit() after Platform.exit(), to close still running event threads like the one from AWT. I put that into a method to comment a bit on it.