### PR TITLE
refactored detection of account and replay directories

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/files/AccountDirectoryWatcher.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/files/AccountDirectoryWatcher.java
@@ -43,7 +43,7 @@ public class AccountDirectoryWatcher implements Closeable {
 
     @Inject
     public AccountDirectoryWatcher(StormHandler stormHandler) {
-        watchDirectories = new HashSet<>(stormHandler.getHotSAccountDirectories());
+        watchDirectories = new HashSet<>(stormHandler.getReplayDirectories());
         threads = new HashSet<>();
         beginWatch();
     }


### PR DESCRIPTION
Work in progress. Will extract the URI specific information to AccountService

EDIT: Refactoring for 2.1 instead as the result will be StormHandler being deleted in the end.

Since this worked differently on various platforms, it should be tested in the various configurations we support.