### PR TITLE
[Bugfix] disable preloader conditionally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
                     <nativeReleaseVersion>${releaseVersion}</nativeReleaseVersion>
                     <identifier>${project.build.finalName}</identifier>
                     <css2bin>true</css2bin>
-                    <preLoader>ninja.eivind.hotsreplayuploader.ClientPreloader</preLoader>
 
                     <jvmArgs>
                         <jvmArg>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -15,6 +15,7 @@
 package ninja.eivind.hotsreplayuploader;
 
 import com.gluonhq.ignite.DIContext;
+import com.sun.javafx.application.LauncherImpl;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.fxml.FXMLLoader;
@@ -27,6 +28,7 @@ import ninja.eivind.hotsreplayuploader.di.GuiceModule;
 import ninja.eivind.hotsreplayuploader.models.stringconverters.StatusBinder;
 import ninja.eivind.hotsreplayuploader.services.platform.PlatformNotSupportedException;
 import ninja.eivind.hotsreplayuploader.services.platform.PlatformService;
+import ninja.eivind.hotsreplayuploader.services.platform.PlatformServiceProvider;
 import ninja.eivind.hotsreplayuploader.utils.Constants;
 import ninja.eivind.hotsreplayuploader.versions.ReleaseManager;
 import org.slf4j.Logger;
@@ -54,7 +56,14 @@ public class Client extends Application {
     private StatusBinder statusBinder;
 
     public static void main(String... args) {
-        launch(Client.class, args);
+        PlatformService platformService = new PlatformServiceProvider().get();
+        if (platformService.isPreloaderSupported()) {
+            LOG.info("Launching with preloader.");
+            LauncherImpl.launchApplication(Client.class, ClientPreloader.class, args);
+        } else {
+            LOG.info("Launching without preloader.");
+            launch(Client.class, args);
+        }
     }
 
     @Override

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -61,4 +61,9 @@ public class LinuxService implements PlatformService {
     public URL getLogoUrl() {
         return getClass().getResource("/images/logo-desktop.png");
     }
+
+    @Override
+    public boolean isPreloaderSupported() {
+        return false;
+    }
 }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
@@ -81,6 +81,11 @@ public class OSXService implements PlatformService {
     }
 
     @Override
+    public boolean isPreloaderSupported() {
+        return false;
+    }
+
+    @Override
     public TrayIcon getTrayIcon(final Stage primaryStage) throws PlatformNotSupportedException {
         final URL imageURL = getLogoUrl();
         return buildTrayIcon(imageURL, primaryStage);

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/PlatformService.java
@@ -100,4 +100,6 @@ public interface PlatformService {
     void browse(URI uri) throws IOException;
 
     URL getLogoUrl();
+
+    boolean isPreloaderSupported();
 }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
@@ -80,6 +80,11 @@ public class WindowsService implements PlatformService {
         return getClass().getResource("/images/logo-desktop.png");
     }
 
+    @Override
+    public boolean isPreloaderSupported() {
+        return true;
+    }
+
     private File findMyDocuments() throws FileNotFoundException {
         Process p = null;
         String myDocuments = null;


### PR DESCRIPTION
Proposed fix for #74 by allowing the maintainers for various platforms to decide for themselves whether or not the preloader feature is active for their platform.

Needs verification that it solves the problem with CMD+H spawning an about dialog on OSX.