### PR TITLE
LinuxService: getHotSHome() fix by using xdg config for Documents folder

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -15,16 +15,22 @@
 package ninja.eivind.hotsreplayuploader.services.platform;
 
 import java.awt.*;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@link PlatformService} that is active on GNU/Linux systems.
  */
 public class LinuxService implements PlatformService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxService.class);
     private Desktop desktop;
 
     public LinuxService() {
@@ -38,13 +44,51 @@ public class LinuxService implements PlatformService {
         return new File(USER_HOME, APPLICATION_DIRECTORY_NAME);
     }
 
+    /**
+     * Returns user-configured path for 'Documents' folder, or null if failed.
+     * Tries to open ~/.config/user-dirs.dirs and parse its content.
+     * @see <a href="http://freedesktop.org/wiki/Software/xdg-user-dirs/">freedesktop specs</a>.
+     * @return String path to folder, or null on error
+     */
+    private String getXDGDocumentsPath() {
+        String path = null;
+        final File file = new File(USER_HOME, ".config/user-dirs.dirs");
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+            String line;
+            while((line = br.readLine()) != null) {
+                // we want to find a line like:
+                // XDG_DOCUMENTS_DIR="$HOME/Documents"
+                if (line.charAt(0) == '#') continue;  // skip comments
+                // check for our magic line
+                if (line.startsWith("XDG_DOCUMENTS_DIR=\"$HOME/")) {
+                    // cut the contents of line, after $HOME/ up to last symbol "
+                    // XDG_DOCUMENTS_DIR="$HOME/Documents"
+                    //                          ^_______^
+                    path = line.substring(25, line.length()-1); // 25 == "XDG_DOCUMENTS_DIR=\"$HOME/".length()
+                    break;
+                }
+            }
+            br.close();
+        } catch (IOException ioe) {
+            LOG.error("Failed to read XDG user-dirs config file " + file.toString());
+        } catch (StringIndexOutOfBoundsException e) {
+            LOG.error("Error parsing XDG user-dirs config file " + file.toString());
+        }
+        return path;
+    }
+
     @Override
     public File getHotSHome() {
         final File file = new File(USER_HOME, "Heroes of the Storm/Accounts/");
         if (file.exists()) {
             return file;
         } else {
-            return new File(USER_HOME, "Documents/Heroes of the Storm/Accounts/");
+            String xdgDefaultDocsPath = "Documents";
+            String xdgDocsPath = this.getXDGDocumentsPath();
+            if (xdgDocsPath == null)
+                xdgDocsPath = xdgDefaultDocsPath;
+            return new File(USER_HOME, xdgDocsPath + "/Heroes of the Storm/Accounts/");
         }
     }
 


### PR DESCRIPTION
Try to parse xdg user-dirs config file to find the correct location of user's "Documents" folder
See http://freedesktop.org/wiki/Software/xdg-user-dirs/ specification.