### PR TITLE
Fix issue #80 (crash on startup)

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -116,7 +116,7 @@ public class Client extends Application {
             systemTray.add(trayIcon);
 
         } catch (PlatformNotSupportedException | AWTException e) {
-            LOG.warn("Could not instantiate tray icon. Reverting to default behaviour", e);
+            LOG.warn("Could not instantiate tray icon. Reverting to default behaviour");
             primaryStage.setOnCloseRequest(event -> Platform.exit());
         }
     }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
@@ -33,11 +33,6 @@ public class ReplayFileComparator implements Comparator<ReplayFile> {
         final File file1 = o1.getFile();
         final File file2 = o2.getFile();
 
-        final int modified = -Long.compare(file1.lastModified(), file2.lastModified());
-        if (modified != 0) {
-            return modified;
-        }
-
-        throw new IllegalStateException("No two different replays can be equal.");
+        return -Long.compare(file1.lastModified(), file2.lastModified());
     }
 }


### PR DESCRIPTION
* Replay file comparator should not throw an exception, which cannot be caught and breaks application startup.
* Don't show exception and stack trace when tray icon is not supported by platform service.