### PR TITLE
Linux: fix getHotSHome() by using xdg user-dirs config

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -77,7 +77,6 @@ public class LinuxService implements PlatformService {
                     break;
                 }
             }
-            br.close();
         } catch (IOException ioe) {
             LOG.error("Failed to read XDG user-dirs config file " + file.toString());
         } catch (StringIndexOutOfBoundsException e) {

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -60,8 +60,8 @@ public class LinuxService implements PlatformService {
             return xdgDocsPath;
         final String lineStart = "XDG_DOCUMENTS_DIR=\"$HOME/";
         final File file = new File(USER_HOME, ".config/user-dirs.dirs");
-        try {
-            BufferedReader br = new BufferedReader(new FileReader(file));
+        // try-with-resources
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
             String line;
             while((line = br.readLine()) != null) {
                 // we want to find a line like:

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -15,27 +15,75 @@
 package ninja.eivind.hotsreplayuploader.services.platform;
 
 import java.awt.*;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * {@link PlatformService} that is active on GNU/Linux systems.
  */
 public class LinuxService implements PlatformService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LinuxService.class);
+    private static final String XDG_DEFAULT_DOCS_PATH = "Documents";
     private Desktop desktop;
+    private String xdgDocsPath;
 
     public LinuxService() {
         if (Desktop.isDesktopSupported()) {
             desktop = Desktop.getDesktop();
         }
+        xdgDocsPath = null;
     }
 
     @Override
     public File getApplicationHome() {
         return new File(USER_HOME, APPLICATION_DIRECTORY_NAME);
+    }
+
+    /**
+     * Returns user-configured path for "Documents" folder, which can be localized string.
+     * Tries to open ~/.config/user-dirs.dirs and parse its content. If opening or parsing fails,
+     * return a default value ("Documents").
+     * @see <a href="http://freedesktop.org/wiki/Software/xdg-user-dirs/">freedesktop specs</a>.
+     * @return String path to user "Documents" folder.
+     */
+    private String getXDGDocumentsPath() {
+        if (xdgDocsPath != null)
+            return xdgDocsPath;
+        final String lineStart = "XDG_DOCUMENTS_DIR=\"$HOME/";
+        final File file = new File(USER_HOME, ".config/user-dirs.dirs");
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+            String line;
+            while((line = br.readLine()) != null) {
+                // we want to find a line like:
+                // XDG_DOCUMENTS_DIR="$HOME/Documents"
+                line = line.trim();  // remove whitespace
+                if (line.charAt(0) == '#') continue;  // skip comments
+                // check for our magic line
+                if (line.startsWith(lineStart)) {
+                    // cut the contents of line, after "...$HOME/" up to last symbol "
+                    // XDG_DOCUMENTS_DIR="$HOME/Documents"
+                    //                          ^_______^
+                    xdgDocsPath = line.substring(lineStart.length(), line.length() - 1);
+                    break;
+                }
+            }
+            br.close();
+        } catch (IOException ioe) {
+            LOG.error("Failed to read XDG user-dirs config file " + file.toString());
+        } catch (StringIndexOutOfBoundsException e) {
+            LOG.error("Error parsing XDG user-dirs config file " + file.toString());
+        }
+        return (xdgDocsPath != null ? xdgDocsPath : XDG_DEFAULT_DOCS_PATH);
     }
 
     @Override
@@ -44,7 +92,8 @@ public class LinuxService implements PlatformService {
         if (file.exists()) {
             return file;
         } else {
-            return new File(USER_HOME, "Documents/Heroes of the Storm/Accounts/");
+            String docsPath = getXDGDocumentsPath();
+            return new File(USER_HOME, docsPath + "/Heroes of the Storm/Accounts/");
         }
     }
 


### PR DESCRIPTION
Try to parse xdg user-dirs config file to find the correct location of user's **"Documents"** folder, which can be localized. See http://freedesktop.org/wiki/Software/xdg-user-dirs/ specification.

Trying to make this less breaking as possible: `getHotSHome()` will try to read config file **only** if default path `USER_HOME/Heroes of the Storm/Accounts/` does not exist, and it has a default value "Documents" in case it could not read real values from config file.