### PR TITLE
Don't upload replays twice

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
@@ -36,12 +36,11 @@ import java.util.List;
  */
 @DatabaseTable(tableName = "ReplayFile")
 public class ReplayFile implements Serializable {
-
     private static final Logger LOG = LoggerFactory.getLogger(ReplayFile.class);
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5416365418274150142L;
     private final BooleanProperty failedProperty = new SimpleBooleanProperty(null, "failed", false);
     @DatabaseField(generatedId = true)
-    private Long id;
+    private long id;
     private File file;
     @DatabaseField(width = 1023, unique = true)
     private String fileName;
@@ -57,10 +56,6 @@ public class ReplayFile implements Serializable {
         this.fileName = file.toString();
     }
 
-    public static long getSerialVersionUID() {
-        return serialVersionUID;
-    }
-
     public static List<ReplayFile> fromDirectory(File file) {
         final List<ReplayFile> replayFiles = new ArrayList<>();
         final File[] children = file.listFiles((dir, name) -> name.endsWith(".StormReplay"));
@@ -73,14 +68,13 @@ public class ReplayFile implements Serializable {
         }
 
         return replayFiles;
-
     }
 
-    public Long getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(final Long id) {
+    public void setId(final long id) {
         this.id = id;
     }
 

--- a/src/main/java/ninja/eivind/hotsreplayuploader/repositories/OrmLiteFileRepository.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/repositories/OrmLiteFileRepository.java
@@ -15,7 +15,6 @@
 package ninja.eivind.hotsreplayuploader.repositories;
 
 import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.misc.TransactionManager;
 import com.j256.ormlite.spring.DaoFactory;
 import com.j256.ormlite.stmt.DeleteBuilder;
 import com.j256.ormlite.stmt.PreparedQuery;
@@ -24,16 +23,13 @@ import com.j256.ormlite.support.ConnectionSource;
 import ninja.eivind.hotsreplayuploader.di.Initializable;
 import ninja.eivind.hotsreplayuploader.files.AccountDirectoryWatcher;
 import ninja.eivind.hotsreplayuploader.models.ReplayFile;
-
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 /**
@@ -73,10 +69,8 @@ public class OrmLiteFileRepository implements FileRepository, Initializable, Clo
     @Override
     public void updateReplay(final ReplayFile file) {
         try {
-            TransactionManager.callInTransaction(connectionSource, (Callable<Void>) () -> {
-                dao.createOrUpdate(file);
-                return null;
-            });
+            dao.createOrUpdate(file);
+            dao.refresh(file);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -94,12 +88,8 @@ public class OrmLiteFileRepository implements FileRepository, Initializable, Clo
                     if (file.exists()) {
                         return replayFile;
                     } else {
-                        try {
-                            dao.delete(replayFile);
-                            return null;
-                        } catch (SQLException e) {
-                            throw new RuntimeException(e);
-                        }
+                        deleteReplay(replayFile);
+                        return null;
                     }
                 })
                 .filter(file -> file != null) //dont list already deleted files
@@ -108,11 +98,14 @@ public class OrmLiteFileRepository implements FileRepository, Initializable, Clo
 
     private List<ReplayFile> refreshAll(List<ReplayFile> replayFiles) {
         try {
-            final List<ReplayFile> collect = new ArrayList<>();
             final List<ReplayFile> fromDb = dao.queryForAll();
-            collect.addAll(fromDb);
-            replayFiles.stream().filter(file -> !fromDb.contains(file)).forEach(collect::add);
-            return collect;
+
+            //create new db entities for new files
+            replayFiles.stream().
+                    filter(file -> !fromDb.contains(file))
+                    .forEach(file -> createReplay(file));
+            //get all entities again, but fresh from the db
+            return dao.queryForAll();
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -126,6 +119,14 @@ public class OrmLiteFileRepository implements FileRepository, Initializable, Clo
             deleteBuilder.where()
                     .eq("fileName", selectArg);
             dao.delete(deleteBuilder.prepare());
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void createReplay(final ReplayFile replayFile) {
+        try {
+            dao.create(replayFile);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/UploaderService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/UploaderService.java
@@ -71,7 +71,7 @@ public class UploaderService extends ScheduledService<ReplayFile> implements Ini
     public void initialize() {
         LOG.info("Initializing " + getClass().getSimpleName());
         watcher.addFileListener(file -> {
-            fileRepository.deleteByFileName(file);
+            fileRepository.updateReplay(file);
             files.add(file);
             uploadQueue.add(file);
         });


### PR DESCRIPTION
This is a workaround for issue #91.  
I could isolate, why that happens:  
Uploaded files didn't get persisted correctly on a first run. A second run was needed. So that meant, that every file had to be uploaded / parsed twice.

This was fixed by:
- Writing all new replay files to the db and thus updating them again, when uploaded.
- Creating a new ReplayFile entity, when the WatchHandler registers a new entry.
- Refresh after an update or create (needed for the watchhandler)