### PR TITLE
disable validation of migrations, disables checksum validations

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/repositories/DataSourceProvider.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/repositories/DataSourceProvider.java
@@ -60,6 +60,8 @@ public class DataSourceProvider implements Provider<DataSource> {
 
         flyway.setDataSource(dataSource);
 
+        flyway.setValidateOnMigrate(false);
+
         flyway.migrate();
     }
 }


### PR DESCRIPTION
we're not in a development environment where the database can change locally, so this is not needed, fixes #80, refers #81(needs validation)