### PR TITLE
hotfix/2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     
     <prerequisites>
         <maven>3.0</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     
     <prerequisites>
         <maven>3.0</maven>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/Client.java
@@ -116,7 +116,7 @@ public class Client extends Application {
             systemTray.add(trayIcon);
 
         } catch (PlatformNotSupportedException | AWTException e) {
-            LOG.warn("Could not instantiate tray icon. Reverting to default behaviour", e);
+            LOG.warn("Could not instantiate tray icon. Reverting to default behaviour");
             primaryStage.setOnCloseRequest(event -> Platform.exit());
         }
     }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
@@ -36,12 +36,11 @@ import java.util.List;
  */
 @DatabaseTable(tableName = "ReplayFile")
 public class ReplayFile implements Serializable {
-
     private static final Logger LOG = LoggerFactory.getLogger(ReplayFile.class);
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5416365418274150142L;
     private final BooleanProperty failedProperty = new SimpleBooleanProperty(null, "failed", false);
     @DatabaseField(generatedId = true)
-    private Long id;
+    private long id;
     private File file;
     @DatabaseField(width = 1023, unique = true)
     private String fileName;
@@ -57,10 +56,6 @@ public class ReplayFile implements Serializable {
         this.fileName = file.toString();
     }
 
-    public static long getSerialVersionUID() {
-        return serialVersionUID;
-    }
-
     public static List<ReplayFile> fromDirectory(File file) {
         final List<ReplayFile> replayFiles = new ArrayList<>();
         final File[] children = file.listFiles((dir, name) -> name.endsWith(".StormReplay"));
@@ -73,14 +68,13 @@ public class ReplayFile implements Serializable {
         }
 
         return replayFiles;
-
     }
 
-    public Long getId() {
+    public long getId() {
         return id;
     }
 
-    public void setId(final Long id) {
+    public void setId(final long id) {
         this.id = id;
     }
 

--- a/src/main/java/ninja/eivind/hotsreplayuploader/repositories/DataSourceProvider.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/repositories/DataSourceProvider.java
@@ -60,6 +60,8 @@ public class DataSourceProvider implements Provider<DataSource> {
 
         flyway.setDataSource(dataSource);
 
+        flyway.setValidateOnMigrate(false);
+
         flyway.migrate();
     }
 }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/repositories/OrmLiteFileRepository.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/repositories/OrmLiteFileRepository.java
@@ -102,6 +102,7 @@ public class OrmLiteFileRepository implements FileRepository, Initializable, Clo
                         }
                     }
                 })
+                .filter(file -> file != null) //dont list already deleted files
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/UploaderService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/UploaderService.java
@@ -71,7 +71,7 @@ public class UploaderService extends ScheduledService<ReplayFile> implements Ini
     public void initialize() {
         LOG.info("Initializing " + getClass().getSimpleName());
         watcher.addFileListener(file -> {
-            fileRepository.deleteByFileName(file);
+            fileRepository.updateReplay(file);
             files.add(file);
             uploadQueue.add(file);
         });

--- a/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/utils/ReplayFileComparator.java
@@ -33,11 +33,6 @@ public class ReplayFileComparator implements Comparator<ReplayFile> {
         final File file1 = o1.getFile();
         final File file2 = o2.getFile();
 
-        final int modified = -Long.compare(file1.lastModified(), file2.lastModified());
-        if (modified != 0) {
-            return modified;
-        }
-
-        throw new IllegalStateException("No two different replays can be equal.");
+        return -Long.compare(file1.lastModified(), file2.lastModified());
     }
 }


### PR DESCRIPTION
Release sign-off for version 2.0.1. Reply when confident this release is ready, @zhedar.

# TODO:
~~Bump version to 2.0.1~~
~~Verify state of #81~~

# Release notes
This is the release of version 2.0.1 This bugfix release fixes issues related to the new way we save statuses.

## Issues fixed
* ~~#80/#81~~ - 2.0.0 did not start on some systems due to an improper uniqueness check for files.
* ~~#92~~ - Crash on start if replay files were deleted.
* ~~#93~~ - Some file states were not persisted properly and required a double pass through the uploader. Files were however only actually uploaded once.
* ~~UNTAGGED~~ - Fixed an issue where using both the jar and native package would flag the database as corrupted.