### PR TITLE
Add parameter for overriding hots home directory

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/utils/StormHandler.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/utils/StormHandler.java
@@ -91,7 +91,12 @@ public class StormHandler {
     }
 
     private File buildHotSHome() {
-        return platformService.getHotSHome();
+        String hotsHome = System.getProperty("hots.home");
+        if (hotsHome != null) {
+            return new File(hotsHome);
+        } else {
+            return platformService.getHotSHome();
+        }
     }
 
     /**


### PR DESCRIPTION
A feature suggestion. The default detection code does not work for me because I don't link "My Documents" in my wineprefix to my home directory.

This patch allows you to specify the directory manually through the command line with "-Dhots.home=...". 