### PR TITLE
multiple code improvements: squid:S2325, squid:S00122, squid:S1155, squid:UselessParenthesesCheck, squid:S00115

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
@@ -48,8 +48,7 @@ public class ReplayFile implements Serializable {
     @ForeignCollectionField(eager = true)
     private Collection<UploadStatus> uploadStatuses = new ArrayList<>();
 
-    public ReplayFile() {
-    }
+    public ReplayFile() {}
 
     public ReplayFile(final File file) {
         this.file = file;
@@ -89,8 +88,12 @@ public class ReplayFile implements Serializable {
 
     @Override
     public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         final ReplayFile that = (ReplayFile) o;
 
@@ -106,7 +109,7 @@ public class ReplayFile implements Serializable {
     @JsonIgnore
     public Status getStatus() {
         // TODO MAKE MULTIPROVIDER-FRIENDLY
-        if (uploadStatuses.size() < 1) {
+        if (uploadStatuses.isEmpty()) {
             LOG.warn(this + " has no statuses.");
             return Status.NEW;
         }

--- a/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
@@ -147,7 +147,7 @@ public class HotsLogsProvider extends Provider {
 
     }
 
-    private UUID getUUIDForString(String concatenatedString) throws NoSuchAlgorithmException {
+    private static UUID getUUIDForString(String concatenatedString) throws NoSuchAlgorithmException {
         final byte[] hashed = MessageDigest.getInstance("MD5").digest(concatenatedString.getBytes());
         final byte[] reArranged = reArrangeForUUID(hashed);
         return getUUID(reArranged);

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/LinuxService.java
@@ -67,7 +67,9 @@ public class LinuxService implements PlatformService {
                 // we want to find a line like:
                 // XDG_DOCUMENTS_DIR="$HOME/Documents"
                 line = line.trim();  // remove whitespace
-                if (line.charAt(0) == '#') continue;  // skip comments
+                if (line.charAt(0) == '#') {
+                    continue;  // skip comments
+                }
                 // check for our magic line
                 if (line.startsWith(lineStart)) {
                     // cut the contents of line, after "...$HOME/" up to last symbol "
@@ -82,7 +84,7 @@ public class LinuxService implements PlatformService {
         } catch (StringIndexOutOfBoundsException e) {
             LOG.error("Error parsing XDG user-dirs config file " + file.toString());
         }
-        return (xdgDocsPath != null ? xdgDocsPath : XDG_DEFAULT_DOCS_PATH);
+        return xdgDocsPath != null ? xdgDocsPath : XDG_DEFAULT_DOCS_PATH;
     }
 
     @Override

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/OSXService.java
@@ -33,16 +33,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class OSXService implements PlatformService {
     private static final Logger LOG = LoggerFactory.getLogger(OSXService.class);
-    private static final String libraryPath = "/Library/Application Support";
+    private static final String LIBRARY_PATH = "/Library/Application Support";
 
     @Override
     public File getApplicationHome() {
-        return new File(USER_HOME + "/" + libraryPath + "/" + APPLICATION_DIRECTORY_NAME);
+        return new File(USER_HOME + "/" + LIBRARY_PATH + "/" + APPLICATION_DIRECTORY_NAME);
     }
 
     @Override
     public File getHotSHome() {
-        return new File(USER_HOME + "/" + libraryPath + "/" + "Blizzard/Heroes of the Storm/Accounts/");
+        return new File(USER_HOME + "/" + LIBRARY_PATH + "/" + "Blizzard/Heroes of the Storm/Accounts/");
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2325 "private" methods that don't access instance data should be "static".
squid:S00122 Statements should be on separate lines. 
squid:S1155 Collection.isEmpty() should be used to test for emptiness.
squid:UselessParenthesesCheck Useless parentheses around expressions should be removed to prevent any misunderstanding. 
squid:S00115 Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00115
Please let me know if you have any questions.
George Kankava