### PR TITLE
Hotfix/2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.1</version>
+    <version>2.1.1</version>
     
     <prerequisites>
         <maven>3.0</maven>

--- a/src/test/java/ninja/eivind/hotsreplayuploader/ClientTest.java
+++ b/src/test/java/ninja/eivind/hotsreplayuploader/ClientTest.java
@@ -119,6 +119,15 @@ public class ClientTest {
     }
 
     @Test
+    public void testNonSnapshotBuildIsThreeDigitName() throws Exception {
+        final String version = parse.select("project > version").text();
+        final String regex = "(\\d+\\.){2}\\d+";
+        if(!version.contains("-SNAPSHOT")) {
+            assertTrue("Not a development build, and the version is semver compliant.", version.matches(regex));
+        }
+    }
+
+    @Test
     public void testApplicationHasOSXIcon() throws Exception {
         String appName = parse.select("project > name").text();
         File icon = new File("src/main/deploy/package/macosx/" + appName + ".icns");


### PR DESCRIPTION
# Proposed release notes

This bugfix release fixes the issue with invalid version numbers that causes the application to think there's an available update while you're still running the latest version

# Issues fixed
~~#130~~ - Application version can be not semantic number version compliant.