### PR TITLE
Allow lowercase drive labels for Windows

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
@@ -35,7 +35,7 @@ public class WindowsService implements PlatformService {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsService.class);
     private Desktop desktop;
-    private Pattern pathPattern = Pattern.compile("[A-Z]:\\\\(\\\\|(\\w+|\\.)| )+");
+    private Pattern pathPattern = Pattern.compile("[a-zA-Z]:\\\\(\\\\|(\\w+|\\.)| )+");
     private File documentsHome;
     public WindowsService() {
         desktop = Desktop.getDesktop();


### PR DESCRIPTION
It's possible to input lowercase drive labels for Windows drives, but it's not supported by the path matcher regex. Fixes #136
