### PR TITLE
Hotfix/2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.1.1</version>
+    <version>2.1.2</version>
     
     <prerequisites>
         <maven>3.0</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>ninja.eivind.hots</groupId>
             <artifactId>storm-parser</artifactId>
-            <version>0.2.0.RELEASE</version>
+            <version>0.3.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.j256.ormlite</groupId>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
@@ -23,6 +23,7 @@ import ninja.eivind.hotsreplayuploader.utils.SimpleHttpClient;
 import ninja.eivind.stormparser.models.Player;
 import ninja.eivind.stormparser.models.PlayerType;
 import ninja.eivind.stormparser.models.Replay;
+import ninja.eivind.stormparser.models.replaycomponents.GameMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -134,6 +135,10 @@ public class HotsLogsProvider extends Provider {
         // Temporary fix for computer players found until the parser supports this
         if (replayHasComputerPlayers(replay)) {
             LOG.info("Computer players found for replay, tagging as uploaded.");
+            return Status.UNSUPPORTED_GAME_MODE;
+        }
+        if (replay.getInitData().getGameMode() == GameMode.BRAWL) {
+            LOG.info("Brawl detected, which is unsupported by Hotslogs.com. Tagging as unsupported.");
             return Status.UNSUPPORTED_GAME_MODE;
         }
         try {

--- a/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/services/platform/WindowsService.java
@@ -35,7 +35,7 @@ public class WindowsService implements PlatformService {
 
     private static final Logger LOG = LoggerFactory.getLogger(WindowsService.class);
     private Desktop desktop;
-    private Pattern pathPattern = Pattern.compile("[A-Z]:\\\\(\\\\|(\\w+|\\.)| )+");
+    private Pattern pathPattern = Pattern.compile("[a-zA-Z]:\\\\(\\\\|(\\w+|\\.)| )+");
     private File documentsHome;
     public WindowsService() {
         desktop = Desktop.getDesktop();


### PR DESCRIPTION
# Proposed release notes
This bugfix release fixes issues with Windows drive labels, and fixes issues with uploading Brawl replays.

# Issues fixed
~~#136~~ - Windows allows lower case drive labels, but the app does not.
~~#138~~ - Brawls are uploaded even though Hotslogs.com explicitly doesn't support it.