### PR TITLE
Hotfix/2.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
     <version>2.1.3</version>
-    
+
     <prerequisites>
         <maven>3.0</maven>
     </prerequisites>
@@ -57,20 +57,21 @@
         <finalName>${project.name}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <archive>
-                        <index>true</index>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
-                            <mainClass>${mainClass}</mainClass>
-                        </manifest>
-                    </archive>
+                    <classifier>boot</classifier>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                        <phase>
+                            install
+                        </phase>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -80,7 +81,7 @@
                 <configuration>
                     <updateExistingJar>true</updateExistingJar>
                     <nativeReleaseVersion>${releaseVersion}</nativeReleaseVersion>
-                    <identifier>${project.build.finalName}</identifier>
+                    <identifier>${project.name}</identifier>
                     <css2bin>true</css2bin>
 
                     <jvmArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
     
     <prerequisites>
         <maven>3.0</maven>

--- a/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/providers/hotslogs/HotsLogsProvider.java
@@ -137,10 +137,6 @@ public class HotsLogsProvider extends Provider {
             LOG.info("Computer players found for replay, tagging as uploaded.");
             return Status.UNSUPPORTED_GAME_MODE;
         }
-        if (replay.getInitData().getGameMode() == GameMode.BRAWL) {
-            LOG.info("Brawl detected, which is unsupported by Hotslogs.com. Tagging as unsupported.");
-            return Status.UNSUPPORTED_GAME_MODE;
-        }
         try {
             final String matchId = getMatchId(replay);
             LOG.info("Calculated matchId to be" + matchId);


### PR DESCRIPTION
# Proposed release notes
This bugfix reenables Brawl uploads, as they are now supported by Hotslogs.

# Issues fixed
#138 - Brawls were being held back from upload, but Hotslogs now supports it.
#143 - Uber-jars were not properly generated
