### PR TITLE
Use Files#walk as directory travsersal

### DIFF
--- a/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
+++ b/src/main/java/ninja/eivind/hotsreplayuploader/models/ReplayFile.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -67,7 +68,8 @@ public class ReplayFile implements Serializable {
                     .map(ReplayFile::new)
                     .collect(Collectors.toList());
         } catch (IOException exception) {
-            throw new RuntimeException(exception);
+            LOG.debug("Ignored file {}. Cause : {}", file, exception);
+            return Collections.emptyList();
         }
     }
 


### PR DESCRIPTION
Hello,

A pretty explicit commit.
Using Files#walk allows for leverage of the streams api and the use of jdk api rather than custom implementation.
I chose to throw a RuntimeException mostly because it seems to be the policy of the project to prefer that to failing silently. That said it could be interesting to log errors and return a Collections.emptyList() instead.

This is mostly a matter of opinion though.

Regards