### PR TITLE
Hotfix/2.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>ninja.eivind.hots</groupId>
             <artifactId>storm-parser</artifactId>
-            <version>0.3.0.RELEASE</version>
+            <version>0.4.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.j256.ormlite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ninja.eivind</groupId>
     <artifactId>hots-replay-uploader</artifactId>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
 
     <prerequisites>
         <maven>3.0</maven>


### PR DESCRIPTION
# Proposed release notes
This critical bugfix release contains an updated parser which has better support for Heroes of the Storm 2.0, in addition to not completely crashing the replay handling on failure.
# Issues fixed

#157 - StormParser bypassed fallbacks and did not support Heroes 2.0